### PR TITLE
fix: routes 인터페이스 변경, router 함수 추가

### DIFF
--- a/client/ts/index.ts
+++ b/client/ts/index.ts
@@ -2,7 +2,7 @@ import { routes } from "./routes";
 import Router from "./router";
 
 function main() {
-  new Router(routes);
+  const router = new Router(routes);
 }
 
 window.addEventListener("DOMContentLoaded", () => {

--- a/client/ts/router.ts
+++ b/client/ts/router.ts
@@ -1,17 +1,36 @@
-import { route } from "./routes";
+import { PageRoute, Route } from "./routes";
 
 export default class Router {
-  routes: route;
+  routes: Route;
 
-  constructor(routes: route) {
+  constructor(routes: Route) {
     this.routes = routes;
     this.init();
   }
 
-  init() {
-    const loading = this.routes.main.loading();
-    const mainElement = document.querySelector("main") as HTMLElement;
-    mainElement.innerHTML = loading.getHtml();
+  init(): void {
+    const main = this.routes.main.find((e: PageRoute) => e.path === "/loading");
+
+    if (!main) {
+      return;
+    }
+
+    this.paintPage(main);
+
+    document.addEventListener("click", (e: Event) => {
+      this.handleRoutePage(e);
+    });
+  }
+
+  handleRoutePage(event: Event): void {
+    const targetElement = event.target;
+  }
+
+  paintPage(_targetPages: PageRoute): void {
+    const mainPage = _targetPages.component();
+
+    const mainWrapper = document.querySelector("main") as HTMLElement;
+    mainWrapper.innerHTML = mainPage.getHtml();
   }
 
   //   route() {

--- a/client/ts/routes.ts
+++ b/client/ts/routes.ts
@@ -1,18 +1,20 @@
 import { Component } from "./component/component";
 import Loading from "./component/main/loading";
 
-interface Pages {
-  [propName: string]: () => Component;
+interface PageRoute {
+  path: string;
+  component: () => Component;
 }
 
-interface route {
-  main: Pages;
+interface Route {
+  main: PageRoute[];
 }
 
 const routes = {
-  main: {
-    loading: () => new Loading(),
-  },
+  main: [
+    { path: "/loading", component: () => new Loading() },
+    { path: "home", component: () => new Loading() },
+  ],
 };
 
-export { route, routes };
+export { PageRoute, Route, routes };


### PR DESCRIPTION
- PageRoute 인터페이스: path, component 프로퍼티를 추가
- Route 인터페이스: 프로퍼티의 밸류 값을 배열 형태로 변경
- paintPage 함수 : tagetPage를 html에 추가해주는 역할
- handleRoutePage 함수: 화면에 클릭이 발생했을 때 event.target이 dataset으로 링크를 갖고 있다면 paintPage함수로 보내주는 역할